### PR TITLE
Bumped version in cmark.cabal

### DIFF
--- a/cmark.cabal
+++ b/cmark.cabal
@@ -1,5 +1,5 @@
 name:                cmark
-version:             0.3.1
+version:             0.3.2
 synopsis:            Fast, accurate CommonMark (Markdown) parser and renderer
 description:
   This package provides Haskell bindings for


### PR DESCRIPTION
I probably miss something, but it seems that the version should be at least 0.3.2 (as on Hackage).
